### PR TITLE
Refine PDF layout with smaller fonts and color accents

### DIFF
--- a/acta_generator/__init__.py
+++ b/acta_generator/__init__.py
@@ -10,10 +10,10 @@ def generate_acta_pdf(path="acta.pdf"):
     doc = SimpleDocTemplate(
         buffer,
         pagesize=A4,
-        leftMargin=72,
-        rightMargin=72,
-        topMargin=72,
-        bottomMargin=72,
+        leftMargin=50,
+        rightMargin=50,
+        topMargin=50,
+        bottomMargin=50,
     )
 
     styles = getSampleStyleSheet()
@@ -22,6 +22,9 @@ def generate_acta_pdf(path="acta.pdf"):
             name="TitleCentered",
             parent=styles["Title"],
             alignment=1,  # center
+            fontName="Helvetica-Bold",
+            fontSize=16,
+            textColor=colors.HexColor("#003366"),
             spaceAfter=20,
         )
     )
@@ -29,8 +32,20 @@ def generate_acta_pdf(path="acta.pdf"):
         ParagraphStyle(
             name="SectionHeading",
             parent=styles["Heading2"],
+            fontName="Helvetica-Bold",
+            fontSize=12,
+            textColor=colors.HexColor("#005B9A"),
             spaceBefore=20,
             spaceAfter=10,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="BodyTextSmall",
+            parent=styles["BodyText"],
+            fontName="Helvetica",
+            fontSize=9,
+            leading=12,
         )
     )
 
@@ -48,9 +63,11 @@ def generate_acta_pdf(path="acta.pdf"):
         TableStyle(
             [
                 ("GRID", (0, 0), (-1, -1), 0.5, colors.gray),
-                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#F0F0F0")),
+                ("BACKGROUND", (0, 0), (0, -1), colors.HexColor("#E6F2FF")),
+                ("ROWBACKGROUNDS", (0, 0), (-1, -1), [colors.white, colors.HexColor("#F5F5F5")]),
+                ("TEXTCOLOR", (0, 0), (-1, -1), colors.HexColor("#333333")),
                 ("FONTNAME", (0, 0), (-1, -1), "Helvetica"),
-                ("FONTSIZE", (0, 0), (-1, -1), 10),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
                 ("ALIGN", (0, 0), (0, -1), "RIGHT"),
             ]
         )
@@ -60,13 +77,13 @@ def generate_acta_pdf(path="acta.pdf"):
 
     story.append(Paragraph("Orden del Día", styles["SectionHeading"]))
     agenda = "1. Revisión de objetivos<br/>2. Presupuesto<br/>3. Planificación"  # using HTML breaks
-    story.append(Paragraph(agenda, styles["Normal"]))
+    story.append(Paragraph(agenda, styles["BodyTextSmall"]))
 
     story.append(Paragraph("Acuerdos", styles["SectionHeading"]))
     story.append(
         Paragraph(
             "Se acordó avanzar con el plan propuesto y revisar avances en la próxima reunión.",
-            styles["Normal"],
+            styles["BodyTextSmall"],
         )
     )
 


### PR DESCRIPTION
## Summary
- Reduce margins and add custom styles with smaller fonts and professional colors.
- Introduce alternating row colors and subtle accents in the meeting detail table.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b335345f34832c8cc6687f07dc90fa